### PR TITLE
The default domain of WORKSTATION makes using empty domain impossible

### DIFF
--- a/lib/smb2.js
+++ b/lib/smb2.js
@@ -50,7 +50,7 @@ var SMB = (module.exports = function(opt) {
   }
 
   // store authentification
-  this.domain = opt.domain || share.domain || 'WORKSTATION';
+  this.domain = opt.domain || share.domain || '';
   this.username = opt.username || share.username;
   this.password = opt.password || share.password;
 


### PR DESCRIPTION
Empty domain is a valid option for Samba.

The problem is that if you specify opt.domain to be `''` (i.e. empty string), it will default to WORKSTATION. Not what I would want. The other option could be to check if opt.domain or share.domain is `null`. Wouldn't work for the "smb url string", but for options object it would work. And I'd be fine with that.

PS: I have other issues with this library that I'm not able to figure out. It "seems" older files (i.e. anything over a day old) causes `STATUS_ACCESS_DENIED`. When opening the same files in Finder (Mac OSX), renaming/unlinking has no issues. Any advice would be great.

Let me know. Thanks.