### PR TITLE
Update to handling of file attributes in ensureDir

### DIFF
--- a/lib/api/ensureDir.js
+++ b/lib/api/ensureDir.js
@@ -7,7 +7,7 @@ const ensureOneDir = async (path, connection) => {
   try {
     // console.log('ensureOneDir', path, connection);
     const fileOrDir = await requestAsync('open', { path }, connection);
-    if (fileOrDir.FileAttributes.readIntBE(0, 1) === 0x00000010) {
+    if (fileOrDir.FileAttributes.readIntBE(0, 1) & 0x00000010) {
       // See http://download.microsoft.com/DOWNLOAD/9/5/E/95EF66AF-9026-4BB0-A41D-A4F81802D92C/[MS-FSCC].pdf Section 2.6
       await requestAsync('close', fileOrDir, connection);
     } else {


### PR DESCRIPTION
Having the Archive flag set on a directory causes ensureDir() to recognize it exists, but not that it is a directory. This is because the attribute is set to 0x30 because both FILE_ATTRIBUTE_ARCHIVE (0x20) and FILE_ATTRIBUTE_DIRECTORY (0x10) are set. Changing === to & will fix this issue.

A similar issue could occur with:
- FILE_ATTRIBUTE_HIDDEN (0x2)
- FILE_ATTRIBUTE_READONLY (0x1)
- FILE_ATTRIBUTE_SYSTEM (0x4)
- FILE_ATTRIBUTE_TEMPORARY (0x100)